### PR TITLE
removed username from git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Installing
 * Clone the repository
 
 ```bash
-git clone https://leucos@github.com/xbgmsharp/yapdnsui.git
+git clone https://github.com/xbgmsharp/yapdnsui
 cd yapdnsui
 ```
 


### PR DESCRIPTION
When people just need a copy to use the project, they don't need to specify a username.
