### PR TITLE
update sqlite3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "express": "~4.13.3",
-    "serve-favicon": "~2.3.0",
-    "morgan": "~1.6.1",
-    "cookie-parser": "~1.3.5",
     "body-parser": "~1.13.3",
+    "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",
+    "express": "~4.13.3",
     "jade": "~1.11.x",
+    "morgan": "~1.6.1",
     "request": "2.61.x",
-    "sqlite3": "3.0.x"
+    "serve-favicon": "~2.3.0",
+    "sqlite3": "^3.1.1"
   }
 }


### PR DESCRIPTION
this fixes issues with `npm i` on systems with newer nodejs. The update
was performed by running `npm i --save sqlite3@latest`
